### PR TITLE
Vararg dispatch

### DIFF
--- a/multipledispatch/conflict.py
+++ b/multipledispatch/conflict.py
@@ -66,3 +66,7 @@ def ordering(signatures):
             edges[s] = []
     edges = dict((k, [b for a, b in v]) for k, v in edges.items())
     return _toposort(edges)
+
+
+def issubclass_cmp(x, y):
+    return 1 if issubclass(x, y) else -1 if issubclass(y, x) else 0

--- a/multipledispatch/tests/test_conflict.py
+++ b/multipledispatch/tests/test_conflict.py
@@ -55,3 +55,8 @@ def test_ordering():
     ord = ordering(signatures)
     assert ord[0] == (B, B) or ord[0] == (A, C)
     assert ord[-1] == (A, A) or ord[-1] == (A, C)
+
+
+def test_issubclass_cmp():
+    assert sorted([object, A, B], cmp=issubclass_cmp) == \
+           sorted([B, A, object], cmp=issubclass_cmp) == [object, A, B]

--- a/multipledispatch/tests/test_core.py
+++ b/multipledispatch/tests/test_core.py
@@ -155,6 +155,34 @@ def test_namespaces():
     assert foo2(0) == 2
 
 
+def test_varargs():
+    @dispatch([int])
+    def foo(*args):
+        return 'ints'
+
+    @dispatch([float])
+    def foo(*args):
+        return 'floats'
+
+    @dispatch([object])
+    def foo(*args):
+        return 'objects'
+
+    @dispatch(str)
+    def foo(x):
+        return 'one string'
+
+    @dispatch([str])
+    def foo(x, y, z):
+        return 'many strings'
+
+    assert foo(1, 2) == 'ints'
+    assert foo(1.0, 2.0) == 'floats'
+    assert foo(1, 2.0) == 'objects'
+    assert foo('hello') == 'one string'
+    assert foo('hello', 'world', '!') == 'many strings'
+
+
 """
 Fails
 def test_dispatch_on_dispatch():


### PR DESCRIPTION
We designate dispatch on variable number of arguments as a list containing a single type.  Vararg signatures are checked after normal signatures.

``` Python
    @dispatch([int])
    def foo(*args):
        return 'ints'

    @dispatch([float])
    def foo(*args):
        return 'floats'

    @dispatch([object])
    def foo(*args):
        return 'objects'

    assert foo(1, 2) == 'ints'
    assert foo(1.0, 2.0) == 'floats'
    assert foo(1, 2.0) == 'objects'
```
