### PR TITLE
WIP: Add support for Python 3 annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.pyc
+*.idea
+*.egg-info

--- a/multipledispatch/core.py
+++ b/multipledispatch/core.py
@@ -120,6 +120,11 @@ class MethodDispatcher(Dispatcher):
 dispatchers = dict()
 
 
+def ismethod(func):
+    spec = inspect.getargspec(func)
+    return spec and spec.args and spec.args[0] == 'self'
+
+
 def dispatch(*types):
     """ Dispatch function on the types of the inputs
 
@@ -148,6 +153,8 @@ def dispatch(*types):
     """
     types = tuple(types)
     def _(func):
+        if ismethod(func):
+            return method_dispatch(*types)(func)
         name = func.__name__
         if name not in dispatchers:
             dispatchers[name] = Dispatcher(name)
@@ -160,7 +167,7 @@ def dispatch(*types):
 def method_dispatch(*types):
     def _(func):
         name = func.__name__
-        dispatcher = inspect.currentframe().f_back.f_locals.get(name,
+        dispatcher = inspect.currentframe().f_back.f_back.f_locals.get(name,
                 MethodDispatcher(name))
         dispatcher.add(types, func)
         return dispatcher

--- a/multipledispatch/tests/test_annotations.py
+++ b/multipledispatch/tests/test_annotations.py
@@ -1,0 +1,184 @@
+from multipledispatch import dispatch
+from multipledispatch.compatibility import raises
+from pytest import xfail
+
+
+def test_singledispatch():
+    @dispatch
+    def f(x: int):
+        return x + 1
+
+    @dispatch
+    def g(x: int):
+        return x + 2
+
+    @dispatch
+    def f(x: float):
+        return x - 1
+
+    assert f(1) == 2
+    assert g(1) == 3
+    assert f(1.0) == 0
+
+    assert raises(NotImplementedError, lambda: f('hello'))
+
+
+def test_multipledispatch():
+    @dispatch
+    def f(x: int, y: int):
+        return x + y
+
+    @dispatch
+    def f(x: float, y: float):
+        return x - y
+
+    assert f(1, 2) == 3
+    assert f(1.0, 2.0) == -1.0
+
+
+class A(object): pass
+class B(object): pass
+class C(A): pass
+class D(C): pass
+class E(C): pass
+
+
+def test_inheritance():
+    @dispatch
+    def f(x: A):
+        return 'a'
+
+    @dispatch
+    def f(x: B):
+        return 'b'
+
+    assert f(A()) == 'a'
+    assert f(B()) == 'b'
+    assert f(C()) == 'a'
+
+
+def test_inheritance_and_multiple_dispatch():
+    @dispatch
+    def f(x: A, y: A):
+        return type(x), type(y)
+
+    @dispatch
+    def f(x: A, y: B):
+        return 0
+
+    assert f(A(), A()) == (A, A)
+    assert f(A(), C()) == (A, C)
+    assert f(A(), B()) == 0
+    assert f(C(), B()) == 0
+    assert raises(NotImplementedError, lambda: f(B(), B()))
+
+
+def test_competing_solutions():
+    @dispatch
+    def h(x: A):
+        return 1
+
+    @dispatch
+    def h(x: C):
+        return 2
+
+    assert h(D()) == 2
+
+
+def test_competing_multiple():
+    @dispatch
+    def h(x: A, y: B):
+        return 1
+
+    @dispatch
+    def h(x: C, y: B):
+        return 2
+
+    assert h(D(), B()) == 2
+
+
+def test_competing_ambiguous():
+    @dispatch
+    def f(x: A, y: C):
+        return 2
+
+    @dispatch
+    def f(x: C, y: A):
+        return 2
+
+    assert f(A(), C()) == f(C(), A()) == 2
+    # assert raises(Warning, lambda : f(C(), C()))
+
+
+def test_caching_correct_behavior():
+    @dispatch
+    def f(x: A):
+        return 1
+
+    assert f(C()) == 1
+
+    @dispatch
+    def f(x: C):
+        return 2
+
+    assert f(C()) == 2
+
+
+def test_union_types():
+    @dispatch
+    def f(x: (A, C)):
+        return 1
+
+    assert f(A()) == 1
+    assert f(C()) == 1
+
+
+"""
+Fails
+def test_dispatch_on_dispatch():
+    @dispatch(A)
+    @dispatch(C)
+    def q(x):
+        return 1
+
+    assert q(A()) == 1
+    assert q(C()) == 1
+"""
+
+
+def test_methods():
+    class Foo(object):
+        @dispatch
+        def f(self, x: float):
+            return x - 1
+
+        @dispatch
+        def f(self, x: int):
+            return x + 1
+
+        @dispatch
+        def g(self, x: int):
+            return x + 3
+
+
+    foo = Foo()
+    assert foo.f(1) == 2
+    assert foo.f(1.0) == 0.0
+    assert foo.g(1) == 4
+
+
+def test_methods_multiple_dispatch():
+    class Foo(object):
+        @dispatch
+        def f(x: A, y: A):
+            return 1
+
+        @dispatch
+        def f(x: A, y: A):
+            return 2
+
+
+    foo = Foo()
+    assert foo.f(A(), A()) == 1
+    assert foo.f(A(), C()) == 2
+    assert foo.f(C(), C()) == 2

--- a/multipledispatch/tests/test_core.py
+++ b/multipledispatch/tests/test_core.py
@@ -149,11 +149,11 @@ def test_dispatch_on_dispatch():
 
 def test_methods():
     class Foo(object):
-        @method_dispatch(float)
+        @dispatch(float)
         def f(self, x):
             return x - 1
 
-        @method_dispatch(int)
+        @dispatch(int)
         def f(self, x):
             return x + 1
 


### PR DESCRIPTION
Add support for dispatching on Python3 annotations, for example:

``` python
@dispatch
def f(x: int, y: float):
    ...
```

This PR works on functions but isn't working completely on methods (yet!). I need to do some more work on getting the correct bound method...

Also, need to make sure this doesn't break Python 2. I believe it should be fine because the Python3-specific bits are wrapped in error trapping clauses.
