### PR TITLE
Handle union types in add, not dispatch

### DIFF
--- a/multipledispatch/core.py
+++ b/multipledispatch/core.py
@@ -65,8 +65,7 @@ def dispatch(*types, **kwargs):
                 namespace[name] = Dispatcher(name)
             dispatcher = namespace[name]
 
-        for typs in expand_tuples(types):
-            dispatcher.add(typs, func, on_ambiguity=on_ambiguity)
+        dispatcher.add(types, func, on_ambiguity=on_ambiguity)
         return dispatcher
     return _
 
@@ -79,22 +78,3 @@ def ismethod(func):
     """
     spec = inspect.getargspec(func)
     return spec and spec.args and spec.args[0] == 'self'
-
-
-def expand_tuples(L):
-    """
-
-    >>> expand_tuples([1, (2, 3)])
-    [(1, 2), (1, 3)]
-
-    >>> expand_tuples([1, 2])
-    [(1, 2)]
-    """
-    if not L:
-        return [()]
-    elif not isinstance(L[0], tuple):
-        rest = expand_tuples(L[1:])
-        return [(L[0],) + t for t in rest]
-    else:
-        rest = expand_tuples(L[1:])
-        return [(item,) + t for t in rest for item in L[0]]

--- a/multipledispatch/dispatcher.py
+++ b/multipledispatch/dispatcher.py
@@ -1,5 +1,6 @@
 from .conflict import ordering, ambiguities, super_signature, AmbiguityWarning
 from warnings import warn
+from .utils import expand_tuples
 
 
 def ambiguity_warn(dispatcher, ambiguities):
@@ -89,6 +90,12 @@ class Dispatcher(object):
         with a dispatcher/itself, and a set of ambiguous type signature pairs
         as inputs.  See ``ambiguity_warn`` for an example.
         """
+        # Handle union types
+        if any(isinstance(typ, tuple) for typ in signature):
+            for typs in expand_tuples(signature):
+                self.add(typs, func, on_ambiguity)
+            return
+
         self.funcs[signature] = func
         self.ordering = ordering(self.funcs)
         amb = ambiguities(self.funcs)

--- a/multipledispatch/tests/test_dispatcher.py
+++ b/multipledispatch/tests/test_dispatcher.py
@@ -24,6 +24,14 @@ def test_dispatcher():
     assert f(1.0) == 0.0
 
 
+def test_union_types():
+    f = Dispatcher('f')
+    f.register((int, float))(inc)
+
+    assert f(1) == 2
+    assert f(1.0) == 2.0
+
+
 def test_dispatcher_as_decorator():
     f = Dispatcher('f')
 

--- a/multipledispatch/utils.py
+++ b/multipledispatch/utils.py
@@ -1,0 +1,17 @@
+def expand_tuples(L):
+    """
+
+    >>> expand_tuples([1, (2, 3)])
+    [(1, 2), (1, 3)]
+
+    >>> expand_tuples([1, 2])
+    [(1, 2)]
+    """
+    if not L:
+        return [()]
+    elif not isinstance(L[0], tuple):
+        rest = expand_tuples(L[1:])
+        return [(L[0],) + t for t in rest]
+    else:
+        rest = expand_tuples(L[1:])
+        return [(item,) + t for t in rest for item in L[0]]


### PR DESCRIPTION
Union types via tuple have always worked in dispatch

``` Python
@dispatch((int, float))
def inc(x):
    return x + 1

>>> inc(1)
2
>>> inc(1.0)
2.0
```

However until now they didn't work with register or add

``` Python
inc = Dispatcher('inc')

@inc.register((int, float))
def _(x):
    return x + 1
```

This used to raise an exception.  Now it works as above.
