### PR TITLE
Provide a switch to turn off reordering 

### DIFF
--- a/multipledispatch/__init__.py
+++ b/multipledispatch/__init__.py
@@ -1,5 +1,4 @@
 from .core import dispatch
-from .dispatcher import (Dispatcher, halt_method_resolution,
-        restart_method_resolution)
+from .dispatcher import Dispatcher, halt_ordering, restart_ordering
 
 __version__ = '0.4.4'

--- a/multipledispatch/dispatcher.py
+++ b/multipledispatch/dispatcher.py
@@ -24,11 +24,11 @@ _unresolved_dispatchers = set()
 _resolve = [True]
 
 
-def halt_method_resolution():
+def halt_ordering():
     _resolve[0] = False
 
 
-def restart_method_resolution(on_ambiguity=ambiguity_warn):
+def restart_ordering(on_ambiguity=ambiguity_warn):
     _resolve[0] = True
     while _unresolved_dispatchers:
         dispatcher = _unresolved_dispatchers.pop()

--- a/multipledispatch/tests/test_dispatcher.py
+++ b/multipledispatch/tests/test_dispatcher.py
@@ -1,5 +1,5 @@
 from multipledispatch.dispatcher import (Dispatcher, MethodDispatcher,
-        halt_method_resolution, restart_method_resolution)
+        halt_ordering, restart_ordering)
 from multipledispatch.utils import raises
 
 
@@ -137,7 +137,7 @@ def test_halt_method_resolution():
 
     f = Dispatcher('f')
 
-    halt_method_resolution()
+    halt_ordering()
 
     def func(*args):
         pass
@@ -147,7 +147,7 @@ def test_halt_method_resolution():
 
     assert g == [0]
 
-    restart_method_resolution(on_ambiguity=on_ambiguity)
+    restart_ordering(on_ambiguity=on_ambiguity)
 
     assert g == [1]
 


### PR DESCRIPTION
Fixes https://github.com/mrocklin/multipledispatch/issues/7

Dispatchers store type signatures in a list.  Given any input this input is checked against this list _in order_ and the first match succeeds.  So that this is consistent with inheritance this list must be ordered very carefully.  In fact it is a topological sort of a particular DAG.

Currently we recompute this list on every additional signature.  Sadly this can become expensive if the number of signatures becomes very high.  Furthermore it is wasteful because we only need to compute the order at the end.

This PR introduces two functions, `halt_method_resolution` and `restart_method_resolution` which turn off and on this behavior.  As a result code like the following should be much faster than without these calls.

``` Python
halt_ordering()

@dispatch(...)
def func(...):
    pass

import more_dispatched_functions

restart_ordering()
```

These functions could use better names.
