### PR TITLE
Raise NotImplementedError if Dispatcher with no implementations is called

### DIFF
--- a/multipledispatch/dispatcher.py
+++ b/multipledispatch/dispatcher.py
@@ -64,6 +64,7 @@ class Dispatcher(object):
         self.name = name
         self.funcs = dict()
         self._cache = dict()
+        self.ordering = []
 
     def register(self, *types, **kwargs):
         """ register dispatcher with new implementation

--- a/multipledispatch/tests/test_dispatcher.py
+++ b/multipledispatch/tests/test_dispatcher.py
@@ -153,3 +153,8 @@ def test_halt_method_resolution():
 
     print(list(f.ordering))
     assert set(f.ordering) == set([(int, object), (object, int)])
+
+
+def test_no_implementations():
+    f = Dispatcher('f')
+    assert raises(NotImplementedError, lambda: f('hello'))


### PR DESCRIPTION
Previously, the error raised was AttributeError, since the 'ordering'
attribute is only set when the first implementation is added.
