### PR TITLE
Allow passing a docstring to Dispatcher

### DIFF
--- a/docs/source/design.rst
+++ b/docs/source/design.rst
@@ -75,6 +75,46 @@ syntax to register functions as we define them.
 This is equivalent to the form above. It also adheres to the standard
 implemented by ``functools.singledispatch`` in Python 3.4.
 
+
+The Dispatcher creates a detailed docstring automatically.
+To add a description of the multimethod itself,
+provide it when creating the ``Dispatcher``.
+
+.. code::
+
+    >>> f = Dispatcher('f', doc="Do something to the argument")
+
+    >>> @f.register(int)
+    ... def inc(x):
+    ...     "Integers are incremented"
+    ...     return x + 1
+
+    >>> @f.register(float)
+    ... def dec(x):
+    ...     "Floats are decremented"
+    ...     return x - 1
+
+    >>> @f.register(str)
+    ... def rev(x):
+    ...     # no docstring
+    ...     return x[::-1]
+
+    >>> print(f.__doc__)
+    Multiply dispatched method: f
+
+    Do something to the argument
+
+    Inputs: <float>
+    ----------------
+    Floats are decremented
+
+    Inputs: <int>
+    --------------
+    Integers are incremented
+
+    Other signatures:
+        str
+
 Namespaces and ``dispatch``
 ---------------------------
 

--- a/multipledispatch/dispatcher.py
+++ b/multipledispatch/dispatcher.py
@@ -58,13 +58,14 @@ class Dispatcher(object):
     >>> f(3.0)
     2.0
     """
-    __slots__ = 'name', 'funcs', 'ordering', '_cache'
+    __slots__ = 'name', 'funcs', 'ordering', '_cache', 'doc'
 
-    def __init__(self, name):
+    def __init__(self, name, doc=None):
         self.name = name
         self.funcs = dict()
         self._cache = dict()
         self.ordering = []
+        self.doc = doc
 
     def register(self, *types, **kwargs):
         """ register dispatcher with new implementation
@@ -197,9 +198,11 @@ class Dispatcher(object):
 
     @property
     def __doc__(self):
-        doc = " Multiply dispatched method: %s\n\n" % self.name
+        docs = ["Multiply dispatched method: %s" % self.name]
 
-        docs = []
+        if self.doc:
+            docs.append(self.doc)
+
         other = []
         for sig in self.ordering[::-1]:
             func = self.funcs[sig]
@@ -211,13 +214,10 @@ class Dispatcher(object):
             else:
                 other.append(str_signature(sig))
 
-        doc += '\n\n'.join(docs)
-
         if other:
-            doc += '\n\nOther signatures:\n    '
-            doc += '\n\    '.join(other)
+            docs.append('Other signatures:\n    ' + '\n    '.join(other))
 
-        return doc
+        return '\n\n'.join(docs)
 
 
 class MethodDispatcher(Dispatcher):

--- a/multipledispatch/tests/test_dispatcher.py
+++ b/multipledispatch/tests/test_dispatcher.py
@@ -118,7 +118,9 @@ def test_docstring():
     def three(x, y):
         return x + y
 
-    f = Dispatcher('f')
+    master_doc = 'Doc of the multimethod itself'
+
+    f = Dispatcher('f', doc=master_doc)
     f.add((object, object), one)
     f.add((int, int), two)
     f.add((float, float), three)
@@ -128,6 +130,7 @@ def test_docstring():
     assert f.__doc__.find(one.__doc__.strip()) < \
             f.__doc__.find(two.__doc__.strip())
     assert 'object, object' in f.__doc__
+    assert master_doc in f.__doc__
 
 
 def test_halt_method_resolution():


### PR DESCRIPTION
This allows documenting multimethods themselves, not just individual
implementations.

Obviously this will not work with @dispatch, since in that
case there's no single registration point where the documentation
could be attached.

Also, prefer more str.join() over repeated string concatenation
when building the docstring.
