### PR TITLE
Fix DeprecationWarning's, test more python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ python:
     - "2.7"
     - "3.2"
     - "3.3"
+    - "3.4"
+    - "3.5"
     - "pypy"
 
 install:
@@ -13,7 +15,8 @@ script:
     - nosetests --with-doctest
 
 after_success:
-    - if [[ $TRAVIS_PYTHON_VERSION != 'pypy' ]]; then pip install coveralls --use-mirrors ; coveralls ; fi
+    - |
+      if [[ $TRAVIS_PYTHON_VERSION != 'pypy' ]]; then pip install coveralls --use-mirrors ; coveralls ; fi
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,14 @@ python:
     - "pypy"
 
 install:
-    - pip install coverage --use-mirrors
+    - pip install coverage
 
 script:
     - nosetests --with-doctest
 
 after_success:
     - |
-      if [[ $TRAVIS_PYTHON_VERSION != 'pypy' ]]; then pip install coveralls --use-mirrors ; coveralls ; fi
+      if [[ $TRAVIS_PYTHON_VERSION != 'pypy' ]]; then pip install coveralls; coveralls ; fi
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
     - "3.3"
     - "3.4"
     - "3.5"
+    - "3.6-dev"
     - "pypy"
 
 install:

--- a/multipledispatch/core.py
+++ b/multipledispatch/core.py
@@ -76,5 +76,9 @@ def ismethod(func):
     Note that this has to work as the method is defined but before the class is
     defined.  At this stage methods look like functions.
     """
-    spec = inspect.getargspec(func)
-    return spec and spec.args and spec.args[0] == 'self'
+    if hasattr(inspect, "signature"):
+        signature = inspect.signature(func)
+        return signature.parameters.get('self', None) != None
+    else:
+        spec = inspect.getargspec(func)
+        return spec and spec.args and spec.args[0] == 'self'

--- a/multipledispatch/tests/test_dispatcher.py
+++ b/multipledispatch/tests/test_dispatcher.py
@@ -1,3 +1,5 @@
+import warnings
+
 from multipledispatch.dispatcher import (Dispatcher, MethodDispatcher,
         halt_ordering, restart_ordering, MDNotImplementedError)
 from multipledispatch.utils import raises
@@ -20,7 +22,9 @@ def test_dispatcher():
     f.add((int,), inc)
     f.add((float,), dec)
 
-    assert f.resolve((int,)) == inc
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        assert f.resolve((int,)) == inc
     assert f.dispatch(int) is inc
 
     assert f(1) == 2


### PR DESCRIPTION
While working on porting Diofant to Python 3.6, I discover some DeprecationWarning in its dependencies.

This fixes all DeprecationWarning's in the multipledispatch test suite.

I tested all with pytest (I don't know well nosetests to configure it in the same way):
```
$ cat conftest.py
import warnings

import pytest

@pytest.fixture(autouse=True, scope='session')
def enable_deprecationwarnings():
    warnings.simplefilter('error', DeprecationWarning)

$ py.test multipledispatch --doctest-modules
============================= test session starts ==============================
platform linux -- Python 3.6.0b1+, pytest-3.0.3, py-1.4.31, pluggy-0.4.0
rootdir: /home/sk/src/multipledispatch, inifile:
plugins: cov-2.3.1
collected 45 items

multipledispatch/core.py .
multipledispatch/dispatcher.py ....
multipledispatch/utils.py ....
multipledispatch/tests/test_conflict.py .......
multipledispatch/tests/test_core.py ............
multipledispatch/tests/test_dispatcher.py .................

========================== 45 passed in 0.38 seconds ===========================
```

Personally, I would suggest using pytest (and pytest-warnings plugin to handle DeprecationWarnings).