### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ This implementation of multiple dispatch is efficient, mostly complete,
 performs static analysis to avoid conflicts, and provides optional namespace
 support.  It looks good too.
 
-See the documentation at http://multiple-dispatch.readthedocs.org/
+See the documentation at https://multiple-dispatch.readthedocs.io/
 
 
 Example
@@ -131,7 +131,7 @@ Links
 .. _`Clojure Protocols`:
   http://clojure.org/protocols
 .. _`Julia methods docs`:
-  http://julia.readthedocs.org/en/latest/manual/methods/
+  https://julia.readthedocs.io/en/latest/manual/methods/
 .. _`Karpinksi notebook: *The Design Impact of Multiple Dispatch*`:
   http://nbviewer.ipython.org/gist/StefanKarpinski/b8fe9dbb36c1427b9f22
 .. _`Wikipedia article`:

--- a/conda.yaml
+++ b/conda.yaml
@@ -17,5 +17,5 @@ requirements:
       - python
 
 about:
-    home: http://multiple-dispatch.readthedocs.org/
+    home: https://multiple-dispatch.readthedocs.io/
     license: BSD


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.