### PR TITLE
setup.py improvements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,7 +106,7 @@ It is, in short, a light weight dependency.
 License
 -------
 
-New BSD. See License_.
+New BSD. See `License file`_.
 
 
 Links
@@ -147,4 +147,4 @@ Links
    :target: https://pypi.python.org/pypi/multipledispatch/
 .. |Coverage Status| image:: https://coveralls.io/repos/mrocklin/multipledispatch/badge.png
    :target: https://coveralls.io/r/mrocklin/multipledispatch
-.. _License: https://github.com/mrocklin/multipledispatch/blob/master/LICENSE.txt
+.. _License file: https://github.com/mrocklin/multipledispatch/blob/master/LICENSE.txt

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,6 @@ setup(name='multipledispatch',
       license='BSD',
       keywords='dispatch',
       packages=['multipledispatch'],
-      long_description=(open('README.md').read() if exists('README.md')
+      long_description=(open('README.rst').read() if exists('README.rst')
                         else ''),
       zip_safe=False)


### PR DESCRIPTION
* Fix error in README.rst:

```
$ python setup.py check -s --restructuredtext --metadata
running check
warning: check: Duplicate implicit target name: "license".

error: Please correct your package.
```

* Fix path to README used in setup.py