### PR TITLE
ENH: optimize import times

### DIFF
--- a/multipledispatch/core.py
+++ b/multipledispatch/core.py
@@ -49,7 +49,6 @@ def dispatch(*types, **kwargs):
     ...         self.data = [datum]
     """
     namespace = kwargs.get('namespace', global_namespace)
-    on_ambiguity = kwargs.get('on_ambiguity', ambiguity_warn)
 
     types = tuple(types)
 
@@ -59,13 +58,14 @@ def dispatch(*types, **kwargs):
         if ismethod(func):
             dispatcher = inspect.currentframe().f_back.f_locals.get(
                 name,
-                MethodDispatcher(name))
+                MethodDispatcher(name),
+            )
         else:
             if name not in namespace:
                 namespace[name] = Dispatcher(name)
             dispatcher = namespace[name]
 
-        dispatcher.add(types, func, on_ambiguity=on_ambiguity)
+        dispatcher.add(types, func)
         return dispatcher
     return _
 

--- a/multipledispatch/dispatcher.py
+++ b/multipledispatch/dispatcher.py
@@ -183,10 +183,10 @@ class Dispatcher(object):
 
     @property
     def ordering(self):
-        ordering = getattr(self, '_ordering', None)
-        if ordering is None:
-            ordering = self.reorder()
-        return ordering
+        try:
+            return self._ordering
+        except AttributeError:
+            return self.reorder()
 
     def reorder(self, on_ambiguity=ambiguity_warn):
         self._ordering = od = ordering(self.funcs)

--- a/multipledispatch/tests/test_dispatcher.py
+++ b/multipledispatch/tests/test_dispatcher.py
@@ -76,18 +76,20 @@ def test_register_instance_method():
 def test_on_ambiguity():
     f = Dispatcher('f')
 
-    def identity(x): return x
+    def identity(x):
+        return x
 
     ambiguities = [False]
 
     def on_ambiguity(dispatcher, amb):
         ambiguities[0] = True
 
-    f.add((object, object), identity, on_ambiguity=on_ambiguity)
+    f.add((object, object), identity)
+    f.add((object, float), identity)
+    f.add((float, object), identity)
+
     assert not ambiguities[0]
-    f.add((object, float), identity, on_ambiguity=on_ambiguity)
-    assert not ambiguities[0]
-    f.add((float, object), identity, on_ambiguity=on_ambiguity)
+    f.reorder(on_ambiguity=on_ambiguity)
     assert ambiguities[0]
 
 
@@ -187,31 +189,6 @@ def test_source_raises_on_missing_function():
     f = Dispatcher('f')
 
     assert raises(TypeError, lambda: f.source(1))
-
-
-def test_halt_method_resolution():
-    g = [0]
-
-    def on_ambiguity(a, b):
-        g[0] += 1
-
-    f = Dispatcher('f')
-
-    halt_ordering()
-
-    def func(*args):
-        pass
-
-    f.add((int, object), func)
-    f.add((object, int), func)
-
-    assert g == [0]
-
-    restart_ordering(on_ambiguity=on_ambiguity)
-
-    assert g == [1]
-
-    assert set(f.ordering) == set([(int, object), (object, int)])
 
 
 def test_no_implementations():


### PR DESCRIPTION
It is currently very expensive to import modules that use multiple dispatch because of all of the ordering that happens at module scope.

This change creates a notion of an unresolved dispatcher which will lazily resolve the order when needed. Dispatchers begin as regular dispatchers with no functions. When `add` is called, the cache is cleared and the object moves into the unresolved state. When the `order` attribute is looked up, the order is computed and the dispatcher moves back to the resolved state. This means that exact matches (resolved in `self.funcs`) will not trigger a reorder. Reordering can be explicitly triggered by calling the `reorder` method. This same machinery applies to the `MethodDispatcher`.

This is implemented by swapping the type under the dispatcher instance to avoid a branch on every call. One simple implementation would be to have a `self._unresolved` flag on the instance; however, this would be slower than the current solution. Most multupledispatch code starts with a large amount of dispatch definitions followed by a considerably larger amount of calls to the dispatcher. I wanted to keep the per-call overhead as low as possible. This implementation also helps by batching sequences of additions and only triggers a single reorder when used.

As a small benchmark, this takes the import time of one component of our code from 7.502 seconds down to 3.210 seconds. Using the existing mutiple dispatch the top calls by total time were:
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
  1742368    0.763    0.000    1.541    0.000 multipledispatch/conflict.py:7(supercedes)
   845865    0.588    0.000    1.185    0.000 multipledispatch/conflict.py:12(consistent)
      175    0.530    0.003    2.206    0.013 multipledispatch/conflict.py:24(ambiguities)
   815514    0.395    0.000    0.565    0.000 {map}
  1695752    0.343    0.000    1.847    0.000 multipledispatch/conflict.py:43(edge)
      175    0.264    0.002    2.131    0.012 multipledispatch/conflict.py:56(ordering)
```
Now, multuple dispatch is not in the top 30.

Another example is a small blaze backend implemented for a custom data format we have. This backend uses 34 calls to `dispatch`, and we spend 2.171 seconds in `restart_ordering`. The total import time for this file was 4.524 seconds. With just this change, this module's import time is down to 0.347 seconds.