### PR TITLE
WIP: Experiment to use pytypes to add support for python type hints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ python:
 install:
     - pip install coverage
     - pip install --upgrade pytest pytest-benchmark
+    - pip install pytypes
 
 script:
     - |

--- a/multipledispatch/conflict.py
+++ b/multipledispatch/conflict.py
@@ -1,4 +1,6 @@
 from .utils import _toposort, groupby
+from pytypes import is_subtype
+
 
 class AmbiguityWarning(Warning):
     pass
@@ -6,13 +8,13 @@ class AmbiguityWarning(Warning):
 
 def supercedes(a, b):
     """ A is consistent and strictly more specific than B """
-    return len(a) == len(b) and all(map(issubclass, a, b))
+    return len(a) == len(b) and all(map(is_subtype, a, b))
 
 
 def consistent(a, b):
     """ It is possible for an argument list to satisfy both A and B """
     return (len(a) == len(b) and
-            all(issubclass(aa, bb) or issubclass(bb, aa)
+            all(is_subtype(aa, bb) or is_subtype(bb, aa)
                            for aa, bb in zip(a, b)))
 
 

--- a/multipledispatch/dispatcher.py
+++ b/multipledispatch/dispatcher.py
@@ -141,10 +141,10 @@ class Dispatcher(object):
 
         >>> D(1, 2)
         3
-        >>> D(1, 2.0)
+        >>> D('1', 2.0)
         Traceback (most recent call last):
         ...
-        NotImplementedError: Could not find signature for add: <int, float>
+        NotImplementedError: Could not find signature for add: <str, float>
         >>> D('s')
         's'
         >>> D(None)

--- a/multipledispatch/tests/test_dispatcher_3only.py
+++ b/multipledispatch/tests/test_dispatcher_3only.py
@@ -4,6 +4,7 @@
 
 from multipledispatch import dispatch
 from multipledispatch.dispatcher import Dispatcher
+import typing
 
 
 def test_function_annotation_register():
@@ -30,8 +31,23 @@ def test_function_annotation_dispatch():
     def inc(x: float):
         return x - 1
 
+    @dispatch()
+    def inc(x: typing.Optional[str]):
+        return x
+
+    @dispatch()
+    def inc(x: typing.List[int]):
+        return x[0] * 4
+
+    @dispatch()
+    def inc(x: typing.List[str]):
+        return x[0] + 'b'
+
     assert inc(1) == 2
     assert inc(1.0) == 0.0
+    assert inc('a') == 'a'
+    assert inc([8]) == 32
+    assert inc(['a']) == 'ab'
 
 
 def test_function_annotation_dispatch_custom_namespace():

--- a/multipledispatch/utils.py
+++ b/multipledispatch/utils.py
@@ -1,3 +1,8 @@
+
+import pytypes
+import typing
+
+
 def raises(err, lamda):
     try:
         lamda()
@@ -14,15 +19,22 @@ def expand_tuples(L):
 
     >>> expand_tuples([1, 2])
     [(1, 2)]
+
+    >>> expand_tuples([1, typing.Optional[str]])
+    [(1, <class 'str'>), (1, <class 'NoneType'>)]
     """
     if not L:
         return [()]
-    elif not isinstance(L[0], tuple):
-        rest = expand_tuples(L[1:])
-        return [(L[0],) + t for t in rest]
     else:
-        rest = expand_tuples(L[1:])
-        return [(item,) + t for t in rest for item in L[0]]
+        if pytypes.is_Union(L[0]):
+           rest = expand_tuples(L[1:])
+           return [(item,) + t for t in rest for item in pytypes.get_Union_params(L[0])]
+        elif not pytypes.is_of_type(L[0], tuple):
+            rest = expand_tuples(L[1:])
+            return [(L[0],) + t for t in rest]
+        else:
+            rest = expand_tuples(L[1:])
+            return [(item,) + t for t in rest for item in L[0]]
 
 
 # Taken from theano/theano/gof/sched.py

--- a/multipledispatch/utils.py
+++ b/multipledispatch/utils.py
@@ -20,8 +20,8 @@ def expand_tuples(L):
     >>> expand_tuples([1, 2])
     [(1, 2)]
 
-    >>> expand_tuples([1, typing.Optional[str]])
-    [(1, <class 'str'>), (1, <class 'NoneType'>)]
+    >>> expand_tuples([1, typing.Optional[str]])  #doctest: +ELLIPSIS
+    [(1, <... 'str'>), (1, <... 'NoneType'>)]
     """
     if not L:
         return [()]


### PR DESCRIPTION
Most of the actual hard bits are delegated to pytypes for determining if types match expected instances.

