### PR TITLE
BUG: fix install in fresh env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
     - "2.7"
-    - "3.3"
     - "3.4"
     - "3.5"
     - "3.6"

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,9 @@
 
 from os.path import exists
 from setuptools import setup
-import multipledispatch
 
 setup(name='multipledispatch',
-      version=multipledispatch.__version__,
+      version='0.6.0',
       description='Multiple dispatch',
       url='http://github.com/mrocklin/multipledispatch/',
       author='Matthew Rocklin',


### PR DESCRIPTION
```
$ pip install multipledispatch==0.6.0 --no-binary :all:
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
Looking in indexes: https://wheels.dynoquant.com/simple, https://pypi.org/simple
Collecting multipledispatch==0.6.0
 Downloading https://files.pythonhosted.org/packages/37/86/76c69eb0dac361c83e2e3952051bec40bd2f488127f5479d6222b5853f04/multipledispatch-0.6.0.tar.gz
   Complete output from command python setup.py egg_info:
   Traceback (most recent call last):
     File "<string>", line 1, in <module>
     File "/private/var/folders/n1/0chtn68x7kj_lkw_z7pk9jmc0000gn/T/pip-install-v6zUZy/multipledispatch/setup.py", line 5, in <module>
       import multipledispatch
     File "multipledispatch/__init__.py", line 1, in <module>
       from .core import dispatch
     File "multipledispatch/core.py", line 3, in <module>
       from .dispatcher import Dispatcher, MethodDispatcher, ambiguity_warn
     File "multipledispatch/dispatcher.py", line 3, in <module>
       from .conflict import ordering, ambiguities, super_signature, AmbiguityWarning
     File "multipledispatch/conflict.py", line 2, in <module>
       from .variadic import isvariadic
     File "multipledispatch/variadic.py", line 1, in <module>
       import six
   ImportError: No module named six
```

Right now we import `multipledispatch` in the setup.py, but now that depends on six, which may not be installed yet. This duplicates the version number, which is one more place to update, but minimizes the amount of code run during the install.