### PR TITLE
Python 3.3 requires coverage<5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ python:
 
 install:
     - pip install --upgrade pip
-    - pip install coverage
+    - pip install 'coverage<5'
     - pip install --upgrade pytest pytest-benchmark
 
 script:


### PR DESCRIPTION
Check fails on Python 3.3 because Coverage requires Python 3.4 or later