### PR TITLE
Source Code Improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 .cache/
 .pytest_cache/
 
+# Virtualenv
+/venv/
+/.venv/
 
 # For CLion or PyCharm
 /.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 *.egg-info/
 .cache/
 .pytest_cache/
+
+
+# For CLion or PyCharm
+/.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
     - "2.7"
-    - "3.3"
     - "3.4"
     - "3.5"
     - "3.6"

--- a/multipledispatch/core.py
+++ b/multipledispatch/core.py
@@ -1,4 +1,5 @@
 import inspect
+import sys
 
 from .dispatcher import Dispatcher, MethodDispatcher, ambiguity_warn
 
@@ -80,5 +81,8 @@ def ismethod(func):
         signature = inspect.signature(func)
         return signature.parameters.get('self', None) is not None
     else:
-        spec = inspect.getargspec(func)
+        if sys.version_info.major < 3:
+            spec = inspect.getargspec(func)
+        else:
+            spec = inspect.getfullargspec(func)
         return spec and spec.args and spec.args[0] == 'self'

--- a/multipledispatch/core.py
+++ b/multipledispatch/core.py
@@ -52,7 +52,7 @@ def dispatch(*types, **kwargs):
 
     types = tuple(types)
 
-    def _(func):
+    def _df(func):
         name = func.__name__
 
         if ismethod(func):
@@ -67,7 +67,7 @@ def dispatch(*types, **kwargs):
 
         dispatcher.add(types, func)
         return dispatcher
-    return _
+    return _df
 
 
 def ismethod(func):

--- a/multipledispatch/dispatcher.py
+++ b/multipledispatch/dispatcher.py
@@ -152,10 +152,10 @@ class Dispatcher(object):
         >>> f([1, 2, 3])
         [3, 2, 1]
         """
-        def _(func):
+        def _df(func):
             self.add(types, func, **kwargs)
             return func
-        return _
+        return _df
 
     @classmethod
     def get_func_params(cls, func):

--- a/multipledispatch/tests/test_dispatcher.py
+++ b/multipledispatch/tests/test_dispatcher.py
@@ -388,7 +388,7 @@ def test_vararg_no_args_failure():
     assert raises(NotImplementedError, f)
 
 
-def test_vararg_no_args_failure():
+def test_vararg_no_args_failure_2():
     f = Dispatcher('f')
 
     @f.register([str])


### PR DESCRIPTION
- Add some git ignore rule in order to allow people who use different Tools to contribute.

- use not deprecated api for Python3.

- Rename local var of decorator from _ to _df.
This can effectively mistakes caused by other contributor, because `_` is really used for non-tracked variable (place/syntax occupier). 