### PR TITLE
Add minimal typing support and fix py3.10

### DIFF
--- a/multipledispatch/dispatcher.py
+++ b/multipledispatch/dispatcher.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import Any, Generic, List, Optional, Tuple, TypeVar
+from typing import Any, Generic, List, Optional, Tuple, TypeVar, get_type_hints
 from warnings import warn
 import inspect
 from .conflict import ordering, ambiguities, super_signature, AmbiguityWarning
@@ -178,14 +178,14 @@ class Dispatcher(Generic[DISPATCHED_RETURN]):
         if params:
             Parameter = inspect.Parameter
 
-            params = (param for param in params
-                      if param.kind in
-                      (Parameter.POSITIONAL_ONLY,
-                       Parameter.POSITIONAL_OR_KEYWORD))
-
+            hints = get_type_hints(func)
             annotations = tuple(
-                param.annotation
-                for param in params)
+                hints.get(param.name, Parameter.empty)
+                for param in params
+                if param.kind in (
+                    Parameter.POSITIONAL_ONLY, Parameter.POSITIONAL_OR_KEYWORD
+                )
+            )
 
             if all(ann is not Parameter.empty for ann in annotations):
                 return annotations

--- a/multipledispatch/tests/test_dispatcher_3only.py
+++ b/multipledispatch/tests/test_dispatcher_3only.py
@@ -17,6 +17,10 @@ def test_function_annotation_register():
     def inc(x: float):
         return x - 1
 
+    @f.register()
+    def inc(x: 'float'):
+        return x - 1
+
     assert f(1) == 2
     assert f(1.0) == 0.0
 


### PR DESCRIPTION
Changes from `inspect.Parameter.annotation` to `typing.get_type_hints` in order to accommodate string annotations from:
- explicit string hints
- PEP 563: default in py 3.10, `from __future__ import annotations` in py <3.9

Also adds some minimal type hints to `Dispatcher` to ease `mypy` typing in downstream use - happy to separate this part.

Resolves #104
