### PR TITLE
Drop support for Python 2.x

### DIFF
--- a/multipledispatch/variadic.py
+++ b/multipledispatch/variadic.py
@@ -1,5 +1,3 @@
-import six
-
 from .utils import typename
 
 
@@ -75,7 +73,7 @@ class VariadicSignatureMeta(type):
         )
 
 
-class Variadic(six.with_metaclass(VariadicSignatureMeta)):
+class Variadic(metaclass=VariadicSignatureMeta):
     """A class whose getitem method can be used to generate a new type
     representing a specific variadic signature.
 


### PR DESCRIPTION
This removes the dependency on `six`, which is increasingly abandoned these days as packages increasingly drop Python 2.x support.