### PR TITLE
Add MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE.txt

--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ It is a light weight dependency.
 License
 -------
 
-New BSD. See `License file`_.
+BSD-3-Clause. See `License file`_.
 
 
 Links


### PR DESCRIPTION
As mentioned in #135 e.g. the `conda-forge` feedstock for this package can not find its `LICENSE.txt`.
This should be fixed by explicitly including it in a `MANIFEST.in` file.

There is a workaround for this, but it forces to the feedstock to explicitly include the raw license file in its `source` section.